### PR TITLE
GAZ-17: Major enhancements to demo creation, listing, and management flows

### DIFF
--- a/demo_creator/assets/base.tcss
+++ b/demo_creator/assets/base.tcss
@@ -12,24 +12,6 @@ Footer {
   dock: bottom;
 }
 
-Button {
-    background: #98c379; /* Green background for buttons */
-    color: #282c34; /* Dark text on buttons */
-    text-style: bold;
-    border: round #98c379;
-    padding: 0 2;
-    margin-top: 2;
-    margin-bottom: 1;
-    width: auto; /* Buttons take only necessary width */
-    align-horizontal: center;
-}
-Button:hover {
-  background: #7b68ee;
-  border: solid #7b68ee;
-}
-Button:focus {
-  border: thick #e0b0ff;
-}
 
 Input {
   border: solid #666666;

--- a/demo_creator/assets/confirm_dialog.tcss
+++ b/demo_creator/assets/confirm_dialog.tcss
@@ -1,0 +1,47 @@
+$accent: rgb(6, 100, 160);
+$accent-dark: rgb(2, 50, 80);
+$accent-light: rgb(220, 240, 255);
+$text: rgb(220, 220, 220);
+$text-muted: rgb(150, 150, 150);
+$background: rgb(15, 15, 20);
+$error: rgb(200, 60, 60);
+$button-bg: rgb(45, 55, 80);
+$button-text: rgb(230, 230, 230);
+$button-text-focus: rgb(255, 255, 255);
+$button-disabled-bg: rgb(40, 40, 50);
+$button-disabled-text: rgb(90, 90, 120);
+
+#confirm_overlay {
+    align: center middle;
+    background: $background;
+    border: double $accent;
+    padding: 2 4;
+    width: 46;
+    min-height: 7;
+    color: $text;
+}
+
+#confirm_message {
+    text-align: center;
+    text-style: bold;
+    color: $accent-light;
+    margin-bottom: 2;
+}
+
+#dialog_buttons {
+    layout: horizontal;
+    content-align: center middle;
+    margin-top: 1;
+}
+#dialog_buttons Button {
+    min-width: 10;
+    border: round $accent;
+    margin: 0 2;
+    background: $button-bg;
+    color: $button-text;
+    text-style: bold;
+}
+#dialog_buttons Button:focus {
+    background: $accent;
+    color: $button-text-focus;
+}

--- a/demo_creator/assets/demo_creator.tcss
+++ b/demo_creator/assets/demo_creator.tcss
@@ -1,25 +1,144 @@
 /* ------ demo_creator.tcss ------ */
 
-#demo_creator_form {
-  width: 70%;
-  max-width: 90;
-  height: auto;
-  align: center middle;
-  background: #2b2b2b;
-  border: round #444444;
-  padding: 2 4;
+$accent: rgb(6, 100, 160);
+$accent-dark: rgb(2, 50, 80);
+$accent-light: rgb(220, 240, 255);
+$text: rgb(220, 220, 220);
+$text-muted: rgb(150, 150, 150);
+$background: rgb(15, 15, 20);
+$error: rgb(200, 60, 60);
+$button-bg: rgb(45, 55, 80);
+$button-text: rgb(230, 230, 230);
+$button-text-focus: rgb(255, 255, 255);
+$button-disabled-bg: rgb(40, 40, 50);
+$button-disabled-text: rgb(90, 90, 120);
+
+/* Main container (matches DemoDetailScreen) */
+#demo_detail_container, #demo_creator_form {
+    width: 70%;
+    max-width: 90;
+    min-width: 40;
+    height: 100%;
+    align: center middle;
+    background: $background;
+    color: $text;
+    border: round $accent-dark;
+    padding: 2 4;
+    layout: vertical;
 }
 
-#demo_creator_form Static {
-  margin-top: 1;
-  margin-bottom: 0;
+/* Screen title */
+#screen_title {
+    height: 3;
+    content-align: center middle;
+    text-style: bold;
+    border: tall $accent;
+    background: $accent-dark;
+    color: $accent-light;
+    margin-bottom: 1;
 }
-#status {
-  text-align: center;
-  margin-top: 1;
-  margin-bottom: 1;
+
+/* Status label */
+#status_label, #status {
+    height: 1;
+    margin-bottom: 1;
+    padding-left: 1;
+    text-align: center;
+    color: $error;
 }
-#demo_creator_form Button {
-  margin-top: 2;
-  width: 100%;
+
+/* Scrollable scroll container for form */
+#demo_scroll_container, #steps_scroll_container {
+    height: 1fr;
+    layout: vertical;
+    overflow-y: auto;
+    padding: 1 2;
+    border: solid $accent;
+    background: $background;
+    margin-bottom: 1;
+}
+
+/* Metadata/step headers and field labels */
+.section_header, .label {
+    text-style: bold;
+    padding-left: 0;
+    margin-top: 1;
+    margin-bottom: 1;
+}
+.step_label {
+    text-style: bold underline;
+    margin-bottom: 1;
+}
+
+/* Each step container */
+.step_container {
+    border: solid $accent-dark;
+    padding: 1 1 0 1;     /* No bottom padding */
+    margin-bottom: 1;
+    background: $background;
+    height: auto;
+}
+.step_container > * {
+    min-height: 1;
+    margin-bottom: 0;
+}
+
+/* Step input fields */
+.step_input, .meta_data, .step_field {
+    color: $text;
+    background: $background;
+    padding-left: 2;
+    margin-bottom: 1;
+}
+
+/* Remove Step (in-row) */
+.step_btn_row {
+    justify-content: flex-end;
+    margin-top: 1;
+    margin-bottom: 0;
+}
+.remove_step_btn {
+    color: $error;
+    text-style: bold;
+    margin-left: 1;
+    margin-top: 0;
+    margin-bottom: 0;
+    background: transparent;
+    border: none;
+}
+
+/* Bottom action buttons row */
+#bottom_buttons_row {
+    layout: horizontal;
+    height: 3;
+    margin-bottom: 1;
+    margin-top: 1;
+    content-align: center middle;
+}
+
+/* Action buttons styling */
+.submit_button, .add_step_btn, .cancel_button {
+    min-width: 12;
+    border: round $accent;
+    margin-right: 2;
+    text-style: bold;
+    padding-left: 3;
+    padding-right: 3;
+}
+.submit_button { background: $accent; color: $accent-light; }
+.add_step_btn  { background: $button-bg; color: $button-text; }
+.cancel_button { background: $button-disabled-bg; color: $button-disabled-text; }
+
+Input {
+    border: round $accent;
+    padding-left: 1;
+    padding-right: 1;
+    margin-bottom: 1;
+    background: $button-bg;
+    color: $button-text;
+}
+
+/* Footer (not scrollable, always at bottom) */
+Footer {
+    height: 1;
 }

--- a/demo_creator/assets/demo_detail.tcss
+++ b/demo_creator/assets/demo_detail.tcss
@@ -1,0 +1,162 @@
+$accent: rgb(6, 100, 160);
+$accent-dark: rgb(2, 50, 80);
+$accent-light: rgb(220, 240, 255);
+$text: rgb(220, 220, 220);
+$text-muted: rgb(150, 150, 150);
+$background: rgb(15, 15, 20);
+$error: rgb(200, 60, 60);
+$button-bg: rgb(45, 55, 80);
+$button-text: rgb(230, 230, 230);
+$button-text-focus: rgb(255, 255, 255);
+$button-disabled-bg: rgb(40, 40, 50);
+$button-disabled-text: rgb(90, 90, 120);
+
+
+#demo_detail_container {
+    height: 100%;
+    width: 100%;
+    layout: vertical;
+    background: $background;
+    color: $text;
+    padding: 1 2;
+}
+
+/* Screen Title */
+#screen_title {
+    height: 3;
+    content-align: center middle;
+    text-style: bold;
+    border: tall $accent;
+    background: $accent-dark;
+    color: $accent-light;
+    margin-bottom: 1;
+}
+
+/* Top buttons row */
+#top_buttons_row {
+    layout: horizontal;
+    height: 3;
+    margin-bottom: 1;
+}
+#top_buttons_row Button {
+    margin-right: 2;
+}
+
+
+#top_buttons_row Button {
+    border: round $accent;
+    padding-left: 2;
+    padding-right: 2;
+    background: $button-bg;
+    color: $button-text;
+}
+
+#top_buttons_row Button:focus {
+    background: $accent;
+    color: $button-text-focus;
+    text-style: bold;
+}
+
+#top_buttons_row Button:disabled {
+    background: $button-disabled-bg;
+    color: $button-disabled-text;
+}
+
+/* Status label */
+#status_label {
+    height: 1;
+    margin-bottom: 1;
+    padding-left: 1;
+}
+
+/* Scroll container (scrollable for large number of steps) */
+#demo_scroll_container {
+    height: 1fr;
+    layout: vertical;
+    overflow-y: auto;
+    padding: 1 2;
+    border: solid $accent;
+}
+
+/* Metadata labels and data */
+.label {
+    text-style: bold;
+    padding-left: 0;
+    margin-top: 1;
+}
+
+/*
+* Removed 'height: 1' from .meta_data to allow content to wrap and grow vertically.
+* Content was being clipped if it was too long for a single line.
+*/
+.meta_data {
+    padding-left: 2;
+    color: $text-muted;
+}
+
+/* Steps container */
+#steps_container {
+    layout: vertical;
+}
+
+/* Each step's group */
+.step_container {
+    border: solid $accent-dark;
+    padding: 1 1;
+    margin-bottom: 1;
+    background: $background;
+    height: auto; /* Explicitly set height to auto to let it grow with its content */
+}
+
+/*
+* The `step_container > *` rule is fine, it just ensures the children of each step
+* container don't shrink below a single line.
+*/
+.step_container > * {
+    min-height: 1;
+}
+
+/* Step labels */
+.step_label {
+    text-style: bold underline;
+    margin-bottom: 1;
+}
+
+/*
+* Removed 'height: 1' from .step_field for the same reason as .meta_data.
+* This allows long URLs or details to wrap and remain visible.
+*/
+.step_field {
+    color: $text;
+    padding-left: 2;
+    margin-bottom: 1;
+}
+
+/* Inputs for editing */
+Input {
+    border: round $accent;
+    padding-left: 1;
+    padding-right: 1;
+    margin-bottom: 1;
+    background: $button-bg;
+    color: $button-text;
+}
+
+/* Section header */
+.section_header {
+    text-style: bold underline;
+    margin-top: 1;
+    margin-bottom: 1;
+}
+
+/* Empty steps */
+.empty_steps {
+    padding-left: 2;
+    color: $text-muted;
+    text-style: italic;
+}
+
+/* Footer */
+Footer {
+    height: 1;
+}

--- a/demo_creator/assets/main_menu.tcss
+++ b/demo_creator/assets/main_menu.tcss
@@ -1,109 +1,117 @@
-/* ------ main_menu.tcss ------ */
+$accent: rgb(6, 100, 160);
+$accent-dark: rgb(2, 50, 80);
+$accent-light: rgb(220, 240, 255);
+$text: rgb(220, 220, 220);
+$text-muted: rgb(150, 150, 150);
+$background: rgb(15, 15, 20);
+$button-bg: rgb(45, 55, 80);
+$button-text: rgb(230, 230, 230);
+$button-text-focus: rgb(255, 255, 255);
+$button-disabled-bg: rgb(40, 40, 50);
+$button-disabled-text: rgb(90, 90, 120);
 
-#main_menu {
-    width: 90%;
-    /* Increased max-width for more overall space */
-    max-width: 130; /* Keep this larger value */
-    min-width: 76;
-    margin-top: 3;
-    padding: 2 4;
-    background: #2b2b2b;
-    border: round #444444;
-    align: center middle;
+#main_menu_container {
+    height: 100%;
+    width: 100%;
+    layout: vertical;
+    background: $background;
+    color: $text;
+    padding: 1 2;
 }
 
-#main_menu_user,
-#main_menu_email {
-    text-align: center;
-    color: #b0c4de;
+/* Titles */
+
+#main_menu_title {
+    content-align: center middle;
+    text-style: bold;
+    height: 3;
+    border: tall $accent;
+    background: $accent-dark;
+    color: $accent-light;
+}
+
+/* User Info */
+
+#user_info,
+#email_info {
+    height: 1;
+    padding-left: 1;
+    color: $text-muted;
+}
+
+/* Buttons container */
+
+#action_buttons {
+    layout: horizontal;
+    height: 3;
+    padding-left: 1;
     margin-bottom: 1;
 }
 
-#create_demo_btn {
-    margin-top: 2;
-    margin-bottom: 2;
-    width: 100%;
+#action_buttons Button {
+    border: round $accent;
+    padding-left: 2;
+    padding-right: 2;
+    background: $button-bg;
+    color: $button-text;
+    margin-right: 2;
 }
+
+#action_buttons Button:focus {
+    background: $accent;
+    color: $button-text-focus;
+    text-style: bold;
+}
+
+#action_buttons Button:disabled {
+    background: $button-disabled-bg;
+    color: $button-disabled-text;
+}
+
+/* Demo list label */
 
 #demo_list_title {
-    text-align: center;
+    padding-left: 1;
     text-style: bold;
-    color: #add8e6;
-    margin-top: 2;
+    height: 1;
     margin-bottom: 1;
 }
 
-#demo_table_header {
-    background: #b0c4de;
-    color: #1e1e1e;
+/* Data Table styling */
+
+#demo_data_table {
+    height: 1fr; /* This will make it fill the available vertical space in the Vertical container */
+    border: solid $accent;
+    padding: 0; /* DataTable handles its own padding */
+}
+
+/* Style the column headers */
+
+.data-table--header {
+    background: $accent-dark;
+    color: $accent-light;
+    text-style: bold underline;
+}
+
+/* Style the selected row */
+
+/*
+.data-table--row:selected {
+    background: $accent;
+    color: $accent-light;
     text-style: bold;
-    padding: 0 1;
-    border-bottom: solid #7b68ee;
-    height: auto;
+}
+*/
+
+
+/* Normal rows */
+
+.data-table--row {
+    border-bottom: dimgray;
 }
 
-/* Table rows */
-.demo_row {
-    background: #23252b;
-    border-bottom: dashed #3a3a3a;
-    padding: 1 0;
-    height: auto; /* Ensure height is auto to contain button content */
-    min-width: 76;
-    max-width: 128; /* Keep this larger value */
-    align: left middle;
-}
-.demo_row:even {
-    background: #282828;
-}
-.demo_col {
-    padding: 0 1;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    height: auto; /* Ensure individual columns can grow vertically if needed */
-    align: left middle; /* Default for most columns */
-}
-.demo_col_name    { width: 22%; min-width: 16; max-width: 24; }
-.demo_col_desc    { width: 45%; min-width: 30; max-width: 48; }
-.demo_col_updated { width: 20%; min-width: 16; max-width: 24; text-align: right; color: #90ee90; }
+/* Footer adjustment */
 
-.demo_col_actions {
-    /* Increased width significantly to fit 3 buttons */
-    width: 20%; /* Keep this, adjust if needed */
-    min-width: 18; /* Keep this, adjust if needed */
-    max-width: 28; /* Keep this, adjust if needed */
-    text-align: center; /* Center the overall group of buttons horizontally */
-    align: center middle; /* Use valid align values for the column itself */
-    height: auto; /* Crucial for buttons to render fully */
-}
-
-/* Action buttons */
-.show_btn, .edit_btn, .delete_btn {
-    padding: 0 1; /* Changed 0.5 to 1 (integer) */
-    min-width: 7; /* Increased slightly to account for integer padding */
-    width: auto;
-    margin-left: 1; /* Changed 0.5 to 1 (integer) */
-    margin-right: 1; /* Changed 0.5 to 1 (integer) */
-    height: auto; /* Allow buttons to determine their own height */
-    text-align: center; /* Ensure text is centered within the button */
-    /* Removed display: inline-block; as it's not supported */
-}
-
-.show_btn   { background: #81dab6; color: #18181c; border: solid #67b595; }
-.edit_btn   { background: #f8e06c; color: #222;    border: solid #ffd700; }
-.delete_btn { background: #e06c75; color: #fff;    border: solid #e06c75; }
-
-.show_btn:hover   { background: #67b595; }
-.edit_btn:hover   { background: #ffe45c; }
-.delete_btn:hover { background: #a9323a; }
-
-Button:focus {
-    border: thick #add8e6;
-}
-
-/* Add some vertical space */
 Footer {
-    background: #222;
-    color: #aaa;
     height: 1;
-    dock: bottom;
 }

--- a/demo_creator/schema.py
+++ b/demo_creator/schema.py
@@ -23,6 +23,11 @@ schema = {
                 }
             },
             "minProperties": 1
+        },
+        "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of required DPG names for this demo"
         }
     }
 }

--- a/demo_creator/screens/ConfirmDialogScreen.py
+++ b/demo_creator/screens/ConfirmDialogScreen.py
@@ -1,0 +1,32 @@
+from textual.screen import Screen
+from textual.containers import Vertical, Horizontal
+from textual.widgets import Static, Button, Label
+
+class ConfirmDialogScreen(Screen):
+    CSS_PATH = "../assets/confirm_dialog.tcss"
+    BINDINGS = []  # prevent escape by default; add if you want
+
+    def __init__(self, message, on_confirm, on_cancel):
+        super().__init__()
+        self.message = message
+        self.on_confirm = on_confirm
+        self.on_cancel = on_cancel
+
+    def compose(self):
+        yield Vertical(
+            Label(self.message, id="confirm_message"),
+            Horizontal(
+                Button("Yes", id="confirm_yes"),
+                Button("No", id="confirm_no"),
+                id="dialog_buttons"
+            ),
+            id="confirm_overlay"
+        )
+
+    def on_button_pressed(self, event):
+        if event.button.id == "confirm_yes":
+            self.app.pop_screen()
+            self.on_confirm()
+        elif event.button.id == "confirm_no":
+            self.app.pop_screen()
+            self.on_cancel()

--- a/demo_creator/screens/DemoDetailScreen.py
+++ b/demo_creator/screens/DemoDetailScreen.py
@@ -1,0 +1,416 @@
+import os
+import json
+import shutil
+from typing import Optional
+
+from textual.screen import Screen
+from textual.containers import Vertical, Horizontal, ScrollableContainer
+from textual.widgets import Static, Input, Button, Footer, Label
+from textual.app import ComposeResult, App
+from textual.binding import Binding
+from jsonschema import validate, ValidationError
+
+from demo_creator.schema import schema
+from demo_creator.screens.ConfirmDialogScreen import ConfirmDialogScreen
+
+
+def get_demo_file_path(demo_id: str) -> Optional[str]:
+    """
+    Finds and returns the full file path for the demo JSON file with the given demo_id.
+    Looks into demos/latest/ folder and metadata.json to get the filename.
+    Returns None if not found.
+    """
+    metadata_path = os.path.join("demos", "latest", "metadata.json")
+    if not os.path.exists(metadata_path):
+        return None
+
+    with open(metadata_path, "r") as f:
+        metadata = json.load(f)
+    demos = metadata.get("demos", [])
+    for demo in demos:
+        if demo.get("demoId") == demo_id and not demo.get("deleted", False):
+            fname = demo.get("file_name") or f'{demo.get("demoName", "").replace(" ", "_")}.json'
+            return os.path.join("demos", "latest", fname)
+    return None
+
+
+def remove_demo_from_metadata(demo_id: str) -> None:
+    """
+    Marks demo as deleted in metadata.json by setting 'deleted': True.
+    """
+    metadata_path = os.path.join("demos", "latest", "metadata.json")
+    if not os.path.exists(metadata_path):
+        return
+
+    with open(metadata_path, "r") as f:
+        metadata = json.load(f)
+
+    updated = False
+    for demo in metadata.get("demos", []):
+        if demo.get("demoId") == demo_id:
+            demo["deleted"] = True
+            updated = True
+            break
+
+    if updated:
+        with open(metadata_path, "w") as f:
+            json.dump(metadata, f, indent=2)
+
+
+class DemoDetailScreen(Screen):
+    CSS_PATH = "../assets/demo_detail.tcss"
+
+    BINDINGS = [
+        Binding("escape", "go_back", "Go Back", show=True),
+    ]
+
+    def __init__(self, demo_id: str) -> None:
+        super().__init__()
+        self.demo_id = demo_id
+        self.demo_data = None
+        self.file_path = None
+        self.edit_mode = False
+        self.inputs = {}
+        self.status_label: Optional[Static] = None
+
+    def compose(self) -> ComposeResult:
+        # Header and main vertical container
+        with Vertical(id="demo_detail_container"):
+            yield Static("Demo Details", id="screen_title")
+
+            # Top-level metadata and buttons container
+            with Horizontal(id="top_buttons_row"):
+                self.btn_edit = Button("Edit", id="edit_btn")
+                yield self.btn_edit
+                self.btn_delete = Button("Delete", id="delete_btn")
+                yield self.btn_delete
+                self.btn_save = Button("Save", id="save_btn", disabled=True)
+                yield self.btn_save
+                self.btn_cancel = Button("Cancel", id="cancel_btn", disabled=True)
+                yield self.btn_cancel
+
+            # Status message label
+            self.status_label = Static("", id="status_label")
+            yield self.status_label
+
+            # Scrollable container for demo info and steps
+            self.scroll_container = ScrollableContainer(id="demo_scroll_container")
+            yield self.scroll_container
+
+            yield Footer()
+
+    def on_mount(self) -> None:
+        self.load_demo_data()
+        self.call_later(self.render_demo_view)
+
+    def load_demo_data(self) -> None:
+        self.file_path = get_demo_file_path(self.demo_id)
+        if not self.file_path or not os.path.exists(self.file_path):
+            self.status_label.update("[red]❌ Demo file not found.")
+            return
+
+        with open(self.file_path, "r") as f:
+            self.demo_data = json.load(f)
+
+    def render_demo_view(self) -> None:
+        if not self.demo_data:
+            return
+
+        self.edit_mode = False
+        self.btn_edit.disabled = False
+        self.btn_delete.disabled = False
+        self.btn_save.disabled = True
+        self.btn_cancel.disabled = True
+
+        # Clear all children from the scroll container
+        self.scroll_container.remove_children()
+
+        # Add static metadata fields directly to the scroll container
+        self.scroll_container.mount(Static("Demo Name:", classes="label"))
+        self.scroll_container.mount(Static(self.demo_data.get("demoName", ""), id="demo_name_static", classes="meta_data"))
+
+        self.scroll_container.mount(Static("Demo Description:", classes="label"))
+        self.scroll_container.mount(Static(self.demo_data.get("demoDescription", "(No description)"), id="demo_desc_static", classes="meta_data"))
+
+        # DPGs/tags display
+        self.scroll_container.mount(Static("Required DPGs:", classes="label"))
+        tags = self.demo_data.get("tags", [])
+        if tags:
+            tags_display = " ".join(
+                f"[b][reverse][white] {tag} [/white][/reverse][/b]" for tag in tags
+            )
+        else:
+            tags_display = "(None)"
+        self.scroll_container.mount(Static(tags_display, id="dpg_tags_static", classes="meta_data"))
+
+        # Populate steps as static labels
+        steps = self.demo_data.get("steps", {})
+        self.log(f"Found {len(steps)} steps for demo '{self.demo_id}'")
+        
+        if not steps:
+            self.scroll_container.mount(Static("No steps found.", classes="empty_steps"))
+            return
+
+        sorted_step_keys = sorted(steps.keys(), key=lambda x: int(x))
+        for step_idx in sorted_step_keys:
+            step = steps[step_idx]
+            step_container = Vertical(
+                Label(f"Step {step_idx}", classes="step_label"),
+                Static(f"Title: {step.get('title', '')}", classes="step_field"),
+                Static(f"URL: {step.get('url', '')}", classes="step_field"),
+                Static(f"Details: {step.get('details', '')}", classes="step_field"),
+                classes="step_container",
+            )
+            self.scroll_container.mount(step_container)
+
+    def render_demo_edit(self) -> None:
+        if not self.demo_data:
+            return
+
+        self.edit_mode = True
+        self.btn_edit.disabled = True
+        self.btn_delete.disabled = True
+        self.btn_save.disabled = False
+        self.btn_cancel.disabled = False
+
+        self.scroll_container.remove_children()
+        self.inputs = {}
+
+        # Add inputs for metadata
+        self.scroll_container.mount(Static("Demo Name:", classes="label"))
+        self.input_demo_name = Input(value=self.demo_data.get("demoName", ""), id="input_demo_name")
+        self.scroll_container.mount(self.input_demo_name)
+
+        self.scroll_container.mount(Static("Demo Description:", classes="label"))
+        self.input_demo_desc = Input(value=self.demo_data.get("demoDescription", ""), id="input_demo_desc")
+        self.scroll_container.mount(self.input_demo_desc)
+
+        self.scroll_container.mount(Static("Required DPGs (comma separated):", classes="label"))
+        tags_array = self.demo_data.get("tags", [])
+        tags_str = ", ".join(tags_array) if tags_array else ""
+        self.input_demo_tags = Input(value=tags_str, id="input_demo_tags")
+        self.scroll_container.mount(self.input_demo_tags)
+
+        self.scroll_container.mount(Static("Steps:", classes="section_header"))
+        # Add inputs for steps
+        steps = self.demo_data.get("steps", {})
+        sorted_step_keys = sorted(steps.keys(), key=lambda x: int(x))
+        for step_idx in sorted_step_keys:
+            step = steps[step_idx]
+
+            # Inputs for this step
+            title_input = Input(value=step.get("title", ""), placeholder="Step Title", classes="step_input")
+            url_input = Input(value=step.get("url", ""), placeholder="Step URL", classes="step_input")
+            details_input = Input(value=step.get("details", ""), placeholder="Step Details", classes="step_input")
+
+            self.inputs[step_idx] = {
+                "title": title_input,
+                "url": url_input,
+                "details": details_input,
+            }
+
+            # Compose everything at construction; do NOT use mount() on detached widgets
+            step_container = Vertical(
+                Label(f"Step {step_idx}", classes="step_label"),
+                Static("Title:", classes="label"),
+                title_input,
+                Static("URL:", classes="label"),
+                url_input,
+                Static("Details:", classes="label"),
+                details_input,
+                classes="step_container"
+            )
+            self.scroll_container.mount(step_container)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        btn_id = event.button.id
+        if btn_id == "edit_btn":
+            self.render_demo_edit()
+            self.status_label.update("")
+        elif btn_id == "delete_btn":
+            self.show_delete_confirmation()
+        elif btn_id == "save_btn":
+            self.handle_save()
+        elif btn_id == "cancel_btn":
+            self.render_demo_view()
+            self.status_label.update("Edit cancelled.")
+        else:
+            pass
+
+    def show_delete_confirmation(self) -> None:
+        def on_confirm():
+            self.delete_demo()
+            # ...refresh logic if needed
+
+        def on_cancel():
+            pass
+
+        dialog = ConfirmDialogScreen(
+            "Are you sure you want to delete this demo?",
+            on_confirm=on_confirm,
+            on_cancel=on_cancel
+        )
+        self.app.push_screen(dialog)
+
+
+
+    def delete_demo(self) -> None:
+        try:
+            if self.file_path and os.path.exists(self.file_path):
+                os.remove(self.file_path)
+            remove_demo_from_metadata(self.demo_id)
+            self.status_label.update("[green]Demo deleted successfully!")
+            self.app.pop_screen()
+            # --- Refresh main menu datatable ---
+            app: App = self.app
+            main_menu_screen = app.screen_stack[-1]
+            if hasattr(main_menu_screen, "reload"):
+                main_menu_screen.reload()
+        except Exception as e:
+            self.status_label.update(f"[red]Failed to delete demo: {e}")
+
+    def handle_save(self) -> None:
+        try:
+            updated_data = {}
+
+            demo_name = self.input_demo_name.value.strip()
+            if not demo_name:
+                self.status_label.update("[red]Demo Name cannot be empty.")
+                return
+
+            updated_data["demoName"] = demo_name
+            demo_desc = self.input_demo_desc.value.strip()
+            if demo_desc:
+                updated_data["demoDescription"] = demo_desc
+
+            tags_raw = self.input_demo_tags.value.strip() if hasattr(self, "input_demo_tags") else ""
+            tags_list = [t.strip() for t in tags_raw.split(",") if t.strip()]
+            updated_data["tags"] = tags_list
+
+            steps = {}
+            for idx, fields in self.inputs.items():
+                title = fields["title"].value.strip()
+                url = fields["url"].value.strip()
+                details = fields["details"].value.strip()
+                if not title:
+                    self.status_label.update(f"[red]Step {idx} Title cannot be empty.")
+                    return
+                steps[str(idx)] = {
+                    "title": title,
+                    "url": url,
+                    "details": details,
+                }
+            updated_data["steps"] = steps
+
+            # Preserve the original demoId and created_at!
+            demo_id = self.demo_data.get("demoId")
+            updated_data["demoId"] = demo_id
+
+            # Validate JSON schema
+            validate(instance=updated_data, schema=schema)
+
+            # Handle file name change if demo name changed
+            from demo_creator.utils import get_demo_file_name, load_metadata, save_metadata, snapshot_latest_to_dated
+            old_file_name = os.path.basename(self.file_path)
+            new_file_name = get_demo_file_name(demo_name)
+            latest_dir = os.path.dirname(self.file_path)
+            new_file_path = os.path.join(latest_dir, new_file_name)
+
+            if new_file_name != old_file_name:
+                if os.path.exists(new_file_path):
+                    self.status_label.update(f"[red]A demo with that name already exists. Choose a different name.")
+                    return
+                os.rename(self.file_path, new_file_path)
+                self.file_path = new_file_path
+
+            # Save updated demo file
+            with open(self.file_path, "w") as f:
+                json.dump(updated_data, f, indent=2)
+
+            # --- Now update only the existing entry in metadata.json ---
+            metadata = load_metadata()
+            username = getattr(self.app, "current_user", "system")
+            import datetime
+            now = datetime.datetime.now(datetime.timezone.utc)
+            now_str = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+            entry = None
+            for d in metadata["demos"]:
+                if d["demoId"] == demo_id:
+                    entry = d
+                    break
+
+            if entry:
+                entry["name"] = demo_name
+                entry["file_name"] = new_file_name
+                entry["description"] = updated_data.get("demoDescription", "")
+                entry["steps_count"] = len(steps)
+                entry["updated_at"] = now_str
+                entry["last_modified_by"] = username
+                entry["deleted"] = False
+                entry["version"] = entry.get("version", 1) + 1
+                entry["tags"] = updated_data.get("tags", [])
+                # created_at and created_by remain unchanged!
+            else:
+                # (Should not happen in edit flow, but fallback!) Create a new one if not found
+                entry = {
+                    "demoId": demo_id,
+                    "name": demo_name,
+                    "file_name": new_file_name,
+                    "description": updated_data.get("demoDescription", ""),
+                    "version": 1,
+                    "steps_count": len(steps),
+                    "created_at": now_str,
+                    "updated_at": now_str,
+                    "created_by": username,
+                    "last_modified_by": username,
+                    "deleted": False,
+                    "tags": [],
+                }
+                metadata["demos"].append(entry)
+
+            save_metadata(metadata)
+
+            # Optional: Versioned snapshot
+            date_str = now.strftime("%Y-%m-%d")
+            time_str = now.strftime("%H-%M-%S")
+            snapshot_latest_to_dated(date_str, time_str, latest_dir=latest_dir)
+
+            self.demo_data = updated_data
+            self.status_label.update("[green]Demo saved successfully!")
+            self.render_demo_view()
+
+        except ValidationError as ve:
+            self.status_label.update(f"[red]Validation Error: {ve.message}")
+        except Exception as e:
+            self.status_label.update(f"[red]Failed to save demo: {e}")
+
+    def update_metadata(self, updated_demo: dict) -> None:
+        metadata_path = os.path.join("demos", "latest", "metadata.json")
+        if not os.path.exists(metadata_path):
+            return
+
+        with open(metadata_path, "r") as f:
+            metadata = json.load(f)
+
+        updated = False
+        for demo in metadata.get("demos", []):
+            if demo.get("demoId") == updated_demo.get("demoId"):
+                demo["name"] = updated_demo.get("demoName", demo.get("name"))
+                if updated_demo.get("demoDescription"):
+                    demo["description"] = updated_demo["demoDescription"]
+                updated = True
+                break
+        if updated:
+            with open(metadata_path, "w") as f:
+                json.dump(metadata, f, indent=2)
+
+    def action_go_back(self) -> None:
+        # Pop and tell main menu to reload
+        self.app.pop_screen()
+        # After the pop, schedule the reload (on next tick so MainMenuScreen is top of stack)
+        app: App = self.app
+        # Find the main menu screen (assuming it's the previous/topmost screen)
+        main_menu_screen = app.screen_stack[-1]  # Or however you manage your stack
+        if hasattr(main_menu_screen, "reload"):
+            main_menu_screen.reload()

--- a/demo_creator/screens/demo_creator.py
+++ b/demo_creator/screens/demo_creator.py
@@ -1,136 +1,195 @@
-import json
-import os
 import uuid
-import datetime
+import os
+import json
+from datetime import datetime, timezone
 from textual.screen import Screen
-from textual.containers import Vertical
-from textual.widgets import Static, Input, Button, Footer
-from textual.app import ComposeResult
+from textual.containers import Vertical, Horizontal, ScrollableContainer
+from textual.widgets import Static, Input, Button, Footer, Label
+from textual.app import ComposeResult, App
 from jsonschema import validate
 from demo_creator.schema import schema
-from demo_creator.utils import (
-    get_demo_file_name,
-    update_metadata,
-    snapshot_latest_to_dated,
-)
+from demo_creator.utils import get_demo_file_name, update_metadata, snapshot_latest_to_dated
 
 class DemoCreatorScreen(Screen):
-    CSS_PATH = "../assets/demo_creator.tcss"
+    CSS_PATH = "../assets/demo_detail.tcss"
+
     def compose(self) -> ComposeResult:
-        with Vertical(id="demo_creator_form"):
-            yield Static("Demo Creator", id="title")
-            self.status = Static("", id="status")
-            yield self.status
-            yield Static("Demo Name:")
-            self.demo_name = Input(placeholder="e.g., Onboarding Walkthrough")
-            yield self.demo_name
-            yield Static("Demo Description (optional):")
-            self.demo_description = Input(placeholder="Short description...")
-            yield self.demo_description
-            yield Static("How many steps?")
-            self.step_count = Input(placeholder="e.g., 3")
-            yield self.step_count
-            yield Button("Start", id="start_button")
-        yield Footer()
-        self.step_index = 1
-        self.total_steps = 0
-        self.demo_data = {}
+        with Vertical(id="demo_detail_container"):
+            yield Static("Create Demo", id="screen_title")
+            # Button row UNDER the title, just like Demo Details
+            with Horizontal(id="top_buttons_row"):
+                self.btn_submit = Button("Submit", id="submit_button")
+                yield self.btn_submit
+                self.btn_add_step = Button("Add Step", id="add_step_button")
+                yield self.btn_add_step
+                self.btn_cancel = Button("Cancel", id="cancel_button")
+                yield self.btn_cancel
+            self.status_label = Static("", id="status_label")
+            yield self.status_label
+            self.scroll_container = ScrollableContainer(id="demo_scroll_container")
+            yield self.scroll_container
+            yield Footer()
+
+    def on_mount(self) -> None:
+        # Source of truth for all field values
+        self.demo_data = {
+            "demoName": "",
+            "demoDescription": "",
+            "tags": [],
+            "steps": [
+                {"title": "", "url": "", "details": ""},
+            ]
+        }
+        self.inputs = {}
+        self.render_form()
+
+    def render_form(self):
+        self.inputs = {}
+        self.scroll_container.remove_children()
+
+        # Demo Name
+        self.scroll_container.mount(Static("Demo Name:", classes="label"))
+        name_input = Input(value=self.demo_data.get("demoName", ""), placeholder="e.g., Onboarding Walkthrough")
+        self.inputs["demoName"] = name_input
+        self.scroll_container.mount(name_input)
+
+        # Demo Description
+        self.scroll_container.mount(Static("Demo Description:", classes="label"))
+        desc_input = Input(value=self.demo_data.get("demoDescription", ""), placeholder="Short description...")
+        self.inputs["demoDescription"] = desc_input
+        self.scroll_container.mount(desc_input)
+
+        # DPGs (tags)
+        self.scroll_container.mount(Static("Required DPGs (comma separated):", classes="label"))
+        dpgs_str = ", ".join(self.demo_data.get("tags", [])) if self.demo_data.get("tags") else ""
+        dpgs_input = Input(value=dpgs_str, placeholder="e.g., MifosX, Payments, Reports")
+        self.inputs["tags"] = dpgs_input
+        self.scroll_container.mount(dpgs_input)
+
+        # Steps Section Title
+        self.scroll_container.mount(Static("Steps:", classes="section_header"))
+
+        # Steps
+        for idx, step in enumerate(self.demo_data["steps"]):
+            step_inputs = {}
+            title_input = Input(value=step.get("title", ""), placeholder="Step Title", classes="step_input")
+            url_input = Input(value=step.get("url", ""), placeholder="Step URL", classes="step_input")
+            details_input = Input(value=step.get("details", ""), placeholder="Step Details", classes="step_input")
+            step_inputs["title"] = title_input
+            step_inputs["url"] = url_input
+            step_inputs["details"] = details_input
+            self.inputs[f"step_{idx}"] = step_inputs
+
+            step_container = Vertical(
+                Label(f"Step {idx+1}", classes="step_label"),
+                Static("Title:", classes="label"),
+                title_input,
+                Static("URL:", classes="label"),
+                url_input,
+                Static("Details:", classes="label"),
+                details_input,
+                Horizontal(
+                    Button(
+                        "Remove Step",
+                        id=f"remove_step_{idx}",
+                        classes="remove_step_btn",
+                        disabled=(len(self.demo_data["steps"]) == 1)
+                    ),
+                    classes="step_btn_row"
+                ),
+                classes="step_container"
+            )
+            self.scroll_container.mount(step_container)
+
+    def add_step(self):
+        self.save_inputs_to_data()
+        self.demo_data["steps"].append({"title": "", "url": "", "details": ""})
+        self.render_form()
+
+    def remove_step(self, idx):
+        self.save_inputs_to_data()
+        if len(self.demo_data["steps"]) > 1 and 0 <= idx < len(self.demo_data["steps"]):
+            del self.demo_data["steps"][idx]
+            self.render_form()
+
+    def save_inputs_to_data(self):
+        self.demo_data["demoName"] = self.inputs["demoName"].value
+        self.demo_data["demoDescription"] = self.inputs["demoDescription"].value
+
+        tags_field = self.inputs.get("tags")
+        if tags_field:
+            tags_raw = tags_field.value.strip()
+            tags = [t.strip() for t in tags_raw.split(",") if t.strip()]
+            self.demo_data["tags"] = tags
+        else:
+            self.demo_data["tags"] = []
+
+        for idx in range(len(self.demo_data["steps"])):
+            if f"step_{idx}" in self.inputs:
+                step_inputs = self.inputs[f"step_{idx}"]
+                self.demo_data["steps"][idx]["title"] = step_inputs["title"].value
+                self.demo_data["steps"][idx]["url"] = step_inputs["url"].value
+                self.demo_data["steps"][idx]["details"] = step_inputs["details"].value
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        label = event.button.label
-        if event.button.id == "start_button":
-            self.start_demo_flow()
-        elif label == "Next":
-            self.capture_step_input()
-        elif label == "Back":
-            self.go_back_step()
-        elif label == "Submit":
-            self.capture_step_input()
+        btn_id = event.button.id
+        if btn_id == "add_step_button":
+            self.add_step()
+        elif btn_id == "submit_button":
+            self.handle_submit()
+        elif btn_id == "cancel_button":
+            self.app.pop_screen()
+        elif btn_id and btn_id.startswith("remove_step_"):
+            idx = int(btn_id.rsplit("_", 1)[1])
+            self.remove_step(idx)
 
-    def clear_form(self):
-        self.query_one("#demo_creator_form").remove_children()
-
-    def start_demo_flow(self):
-        try:
-            count = int(self.step_count.value.strip())
-            if count < 1:
-                raise ValueError("Must be at least 1 step.")
-            self.total_steps = count
-            self.demo_data = {
-                "demoId": str(uuid.uuid4()),
-                "demoName": self.demo_name.value.strip(),
-                "steps": {}
-            }
-            desc = self.demo_description.value.strip()
-            if desc:
-                self.demo_data["demoDescription"] = desc
-            self.clear_form()
-            self.render_step_form()
-        except Exception as e:
-            self.status.update(f"[red]❌ {e}")
-
-    def render_step_form(self):
-        form = self.query_one("#demo_creator_form")
-        form.mount(Static(f"Step {self.step_index} Title:"))
-        self.step_title = Input(placeholder="e.g., Open Dashboard")
-        form.mount(self.step_title)
-        form.mount(Static("Step URL:"))
-        self.step_url = Input(placeholder="e.g., https://example.com")
-        form.mount(self.step_url)
-        form.mount(Static("Step Details:"))
-        self.step_details = Input(placeholder="What happens in this step?")
-        form.mount(self.step_details)
-        step_data = self.demo_data["steps"].get(str(self.step_index))
-        if step_data:
-            self.step_title.value = step_data.get("title", "")
-            self.step_url.value = step_data.get("url", "")
-            self.step_details.value = step_data.get("details", "")
-        if self.step_index > 1:
-            form.mount(Button("Back"))
-        label = "Submit" if self.step_index == self.total_steps else "Next"
-        form.mount(Button(label))
-
-    def capture_step_input(self):
-        self.demo_data["steps"][str(self.step_index)] = {
-            "title": self.step_title.value.strip(),
-            "url": self.step_url.value.strip(),
-            "details": self.step_details.value.strip()
+    def handle_submit(self):
+        self.save_inputs_to_data()
+        demo_name = self.demo_data["demoName"].strip()
+        if not demo_name:
+            self.status_label.update("[red]Demo Name cannot be empty.")
+            return
+        steps = {}
+        for idx, step in enumerate(self.demo_data["steps"], 1):
+            t = step["title"].strip()
+            u = step["url"].strip()
+            d = step["details"].strip()
+            if not t:
+                self.status_label.update(f"[red]Step {idx} Title cannot be empty.")
+                return
+            steps[str(idx)] = {"title": t, "url": u, "details": d}
+        if not steps:
+            self.status_label.update("[red]Must add at least one step.")
+            return
+        demo_data = {
+            "demoId": str(uuid.uuid4()),
+            "demoName": demo_name,
+            "steps": steps,
+            "tags": list(self.demo_data.get("tags", [])),  # <-- Add tags to result JSON
         }
-        self.step_index += 1
-        if self.step_index <= self.total_steps:
-            self.clear_form()
-            self.render_step_form()
-        else:
-            self.finalize()
-
-    def go_back_step(self):
-        self.demo_data["steps"][str(self.step_index)] = {
-            "title": self.step_title.value.strip(),
-            "url": self.step_url.value.strip(),
-            "details": self.step_details.value.strip()
-        }
-        self.step_index = max(1, self.step_index - 1)
-        self.clear_form()
-        self.render_step_form()
-
-    def finalize(self):
+        demo_desc = self.demo_data["demoDescription"].strip()
+        if demo_desc:
+            demo_data["demoDescription"] = demo_desc
         try:
-            validate(instance=self.demo_data, schema=schema)
-            demo_name = self.demo_data["demoName"]
+            validate(instance=demo_data, schema=schema)
             file_name = get_demo_file_name(demo_name)
-            username = getattr(self.app, 'current_user', 'system')
+            username = getattr(self.app, "current_user", "system")
             latest_dir = os.path.join("demos", "latest")
             os.makedirs(latest_dir, exist_ok=True)
             latest_file = os.path.join(latest_dir, file_name)
             with open(latest_file, "w") as f:
-                json.dump(self.demo_data, f, indent=2)
-            update_metadata(self.demo_data, file_name, username)
-            now = datetime.datetime.now()
+                json.dump(demo_data, f, indent=2)
+            update_metadata(demo_data, file_name, username)
+            now = datetime.now(timezone.utc)
             date_str = now.strftime("%Y-%m-%d")
             time_str = now.strftime("%H-%M-%S")
             snapshot_latest_to_dated(date_str, time_str, latest_dir=latest_dir)
             self.app.last_demo_file = latest_file
+            self.status_label.update("[green]Demo created successfully!")
             self.app.pop_screen()
-            self.app.show_upload_screen()
+            app: App = self.app
+            main_menu_screen = app.screen_stack[-1]
+            if hasattr(main_menu_screen, "reload"):
+                main_menu_screen.reload()
         except Exception as ve:
-            self.status.update(f"[red]❌ Validation Error: {ve}")
+            self.status_label.update(f"[red]❌ Validation Error: {ve}")

--- a/demo_creator/screens/main_menu.py
+++ b/demo_creator/screens/main_menu.py
@@ -1,87 +1,140 @@
-import datetime
+import os
+import json
 from textual.screen import Screen
 from textual.containers import Vertical, Horizontal
-from textual.widgets import Static, Button, Footer
+from textual.widgets import Static, Button, Footer, DataTable
 from textual.app import ComposeResult
-import json
-import os
-
-from demo_creator.screens.show_demo import ShowDemoScreen
-from demo_creator.utils import snapshot_latest_to_dated
+from datetime import datetime
+from demo_creator.screens.demo_creator import DemoCreatorScreen
 
 class MainMenuScreen(Screen):
     CSS_PATH = "../assets/main_menu.tcss"
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="main_menu"):
+        """Create child widgets for the main menu screen."""
+        with Vertical(id="main_menu_container"):
+            # Title and user info
             yield Static("Main Menu", id="main_menu_title")
-            yield Static(f"User: {getattr(self.app, 'current_user', '')}", id="main_menu_user")
-            yield Static(f"Email: {getattr(self.app, 'current_email', '')}", id="main_menu_email")
-            yield Button("Create New Demo", id="create_demo_btn")
+            yield Static(f"User: {getattr(self.app, 'current_user', '')}", id="user_info")
+            yield Static(f"Email: {getattr(self.app, 'current_email', '')}", id="email_info")
+
+            # Buttons row
+            with Horizontal(id="action_buttons"):
+                yield Button("Create New Demo", id="create_demo_btn")
+                yield Button("Upload Demo", id="upload_demo_btn")
+                yield Button("Deploy DPG", id="deploy_dpg_btn", disabled=True)
+
+            # Label for demos list
             yield Static("Available Demos:", id="demo_list_title")
 
-            # Header row for the table:
-            with Horizontal(id="demo_table_header"):
-                yield Static("Demo Name", classes="demo_col demo_col_name")
-                yield Static("Description", classes="demo_col demo_col_desc")
-                yield Static("Last Updated", classes="demo_col demo_col_updated")
-                yield Static("Actions", classes="demo_col demo_col_actions")
+            # DataTable widget for demos
+            self.data_table = DataTable(id="demo_data_table")
+            self.data_table.cursor_type = "row"  # Crucial change: enable full row selection
+            yield self.data_table
 
-            for demo in self.get_demo_list():
-                demo_id = demo["demoId"]
-                name = demo["name"]
-                desc = demo["description"][:57] + "..." if len(demo.get("description", "")) > 60 else demo.get("description", "")
-                updated = demo.get("updated_at", "")
-                with Horizontal(classes="demo_row"):
-                    yield Static(name, classes="demo_col demo_col_name")
-                    yield Static(desc, classes="demo_col demo_col_desc")
-                    yield Static(updated, classes="demo_col demo_col_updated")
-                    yield Button("🔍", id=f"show_{demo_id}", classes="show_btn demo_col demo_col_actions")
-                    yield Button("✏️", id=f"edit_{demo_id}", classes="edit_btn demo_col demo_col_actions")
-                    yield Button("🗑️", id=f"delete_{demo_id}", classes="delete_btn demo_col demo_col_actions")
+            # Footer
+            yield Footer()
 
-        yield Footer()
+    def on_mount(self) -> None:
+        """Actions to perform when the screen is mounted."""
+        self.load_demo_list()
+        self.data_table.focus()  # Ensure the data table has keyboard focus
 
-    def get_demo_list(self):
+    def load_demo_list(self) -> None:
+        """Loads the list of demos into the DataTable."""
+        demos = self.get_demo_list()
+        self.data_table.clear(columns=True)
+
+        # Add columns
+        self.data_table.add_column("Demo Name", width=25)
+        self.data_table.add_column("Description", width=45)
+        self.data_table.add_column("Last Updated", width=28)
+        self.data_table.add_column("DPGs Required")
+
+        if not demos:
+            # Show placeholder row if no demos
+            self.data_table.add_row("No demos found.", "", "")
+            return
+
+        # Add each demo as a row; use demoId as row key for selection
+        for demo in demos:
+            name = demo.get("name", "")
+            desc = demo.get("description", "") or ""
+            if len(desc) > 60:
+                desc = desc[:57] + "..."
+            updated = demo.get("updated_at", "")
+            if updated:
+                try:
+                    dt = datetime.fromisoformat(updated.replace('Z', '+00:00'))
+                    updated_str = dt.strftime('%Y-%m-%d %H:%M')
+                except Exception:
+                    updated_str = updated
+            else:
+                updated_str = ""
+            tags = demo.get("tags", [])
+            if tags:
+                tag_chips = " ".join(
+                    f"[bold][bright_black][[/bright_black][/bold][bold][#228B22]{tag}[/#228B22][/bold][bold][bright_black]][/bright_black][/bold]"
+                    for tag in tags
+                )
+            else:
+                tag_chips = ""
+
+            self.data_table.add_row(name, desc, updated_str, tag_chips, key=demo["demoId"])
+
+    def get_demo_list(self) -> list:
+        """Fetches the list of demos from the metadata file, sorted by latest updated first."""
         metadata_path = os.path.join("demos", "latest", "metadata.json")
         if not os.path.exists(metadata_path):
             return []
-        with open(metadata_path, "r") as f:
-            metadata = json.load(f)
-        return [d for d in metadata.get("demos", []) if not d.get("deleted")]
+
+        try:
+            with open(metadata_path, "r") as f:
+                metadata = json.load(f)
+        except json.JSONDecodeError:
+            return []
+
+        demos = [d for d in metadata.get("demos", []) if not d.get("deleted")]
+
+        # Define key function for sorting by 'updated_at'
+        def date_key(demo):
+            val = demo.get("updated_at", "")
+            try:
+                # Replace 'Z' with '+00:00' for ISO8601 compatibility
+                return datetime.fromisoformat(val.replace("Z", "+00:00"))
+            except Exception:
+                return datetime.min  # fallback if date missing or invalid
+
+        # Sort by updated_at (latest first)
+        demos.sort(key=date_key, reverse=True)
+        return demos
+
+    async def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        """
+        Called when a row is selected (Enter key, or double-click with mouse).
+        This event handler should now work correctly because cursor_type is 'row'.
+        """
+        demo_id = event.row_key
+        # Check for the placeholder row's key, which would be 'None'
+        if not demo_id or demo_id == "None":
+            return
+            
+        # Push the next screen with the selected demo's ID
+        from demo_creator.screens.DemoDetailScreen import DemoDetailScreen
+        self.app.push_screen(DemoDetailScreen(demo_id))
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "create_demo_btn":
+        """Handles button presses on the screen."""
+        btn_id = event.button.id
+        if btn_id == "create_demo_btn":
+            self.app.push_screen(DemoCreatorScreen())
+        elif btn_id == "upload_demo_btn":
             self.app.pop_screen()
-            self.app.show_demo_creator()
-        elif event.button.id.startswith("show_"):
-            demo_id = event.button.id.removeprefix("show_")
-            self.show_demo(demo_id)
-        elif event.button.id.startswith("edit_"):
-            demo_id = event.button.id.removeprefix("edit_")
-            self.edit_demo(demo_id)
-        elif event.button.id.startswith("delete_"):
-            demo_id = event.button.id.removeprefix("delete_")
-            self.delete_demo(demo_id)
-            self.refresh()  # reload UI to reflect deletion
+            self.app.show_upload_screen()
+        elif btn_id == "deploy_dpg_btn":
+            # Placeholder, no action for now
+            pass
 
-    def delete_demo(self, demo_id):
-        metadata_path = os.path.join("demos", "latest", "metadata.json")
-        if not os.path.exists(metadata_path):
-            return
-        with open(metadata_path, "r") as f:
-            metadata = json.load(f)
-        for d in metadata.get("demos", []):
-            if d["demoId"] == demo_id:
-                d["deleted"] = True
-                # Also remove the actual demo file from latest/
-                try:
-                    os.remove(os.path.join("demos", "latest", d["file_name"]))
-                except Exception:
-                    pass
-        with open(metadata_path, "w") as f:
-            json.dump(metadata, f, indent=2)
-        now = datetime.datetime.now()
-        date_str = now.strftime("%Y-%m-%d")
-        time_str = now.strftime("%H-%M-%S")
-        snapshot_latest_to_dated(date_str, time_str, latest_dir=os.path.join("demos", "latest"))
+    def reload(self):
+        self.load_demo_list()
+        self.data_table.focus()

--- a/demo_creator/utils.py
+++ b/demo_creator/utils.py
@@ -78,6 +78,7 @@ def update_metadata(demo_data, file_name, username):
         entry["last_modified_by"] = username
         entry["deleted"] = False
         entry["version"] += 1
+        entry["tags"] = demo_data.get("tags", [])
     else:
         entry = {
             "demoId": demo_id,  # Store demoId in metadata as well!
@@ -91,7 +92,7 @@ def update_metadata(demo_data, file_name, username):
             "created_by": username,
             "last_modified_by": username,
             "deleted": False,
-            "tags": []
+            "tags": demo_data.get("tags", [])
         }
         metadata["demos"].append(entry)
 


### PR DESCRIPTION
## Description  
This PR delivers significant upgrades to the demo-creator tool, improving usability, consistency, and feature coverage. The main menu now offers an enhanced, sortable data table for locally stored demos, while the demo creation process has been streamlined into a single, intuitive screen. Editing, deleting, and metadata management have been refined for accuracy and a smoother user experience. All date and time handling is now standardized to UTC.

## What's New  
- **Main Menu Data Table**:  
  Displays all locally stored demos sorted by last updated date (UTC). Includes DPG tags and improved column formatting.  
- **Single-Screen Demo Creation**:  
  Integrated all creation steps into one view.  
  - Add/remove steps dynamically with buttons.  
  - Input DPG names as comma-separated values.  
  - Dynamic scroll for step management.  
- **Demo Details View**:  
  Clicking on a demo in the main menu opens a details screen.  
  - **Edit Mode**: Makes all relevant fields editable, shows DPG tags as blocks, and validates changes before saving.  
  - **Delete Confirmation**: Prompts the user before permanently removing a demo.  
- **Refined Metadata Handling**:  
  Ensures accurate updates during edits and prevents unintended demo ID changes.  
- **UTC Standardization**:  
  All date/time values are stored and displayed in UTC for consistency across features.

## Resolved Tickets  
This PR addresses the following Jira issues:  
- [GAZ-125](https://mifosforge.jira.com/browse/GAZ-125): Add edit demos  
- [GAZ-126](https://mifosforge.jira.com/browse/GAZ-126): Add show demo  
- [GAZ-131](https://mifosforge.jira.com/browse/GAZ-131): Add DPG tagging in create demo and metadata  
- [GAZ-132](https://mifosforge.jira.com/browse/GAZ-132): Display Entered User Details on Main Menu Screen  
- [GAZ-133](https://mifosforge.jira.com/browse/GAZ-133): Refactor Demo File Management Actions (Edit/Delete)  
- [GAZ-137](https://mifosforge.jira.com/browse/GAZ-137): Add refresh on ESC from editing screen for datatable listing demos  
- [GAZ-138](https://mifosforge.jira.com/browse/GAZ-138): Add sorting for demo listings in data-table based on last updated  
- [GAZ-139](https://mifosforge.jira.com/browse/GAZ-139): Add proper UTC-based formatting for last updated datetime shown in data-table  
- [GAZ-140](https://mifosforge.jira.com/browse/GAZ-140): Resolve updating metadata issues on demo edit  
- [GAZ-141](https://mifosforge.jira.com/browse/GAZ-141): Remove demoID modification on demo edit  
- [GAZ-144](https://mifosforge.jira.com/browse/GAZ-144): Add DPG to show and edit demos  
- [GAZ-145](https://mifosforge.jira.com/browse/GAZ-145): Show DPG names in main menu data table  
- [GAZ-146](https://mifosforge.jira.com/browse/GAZ-146): Resolve datetime issues and use UTC always  
- [GAZ-147](https://mifosforge.jira.com/browse/GAZ-147): Add confirmation screen on delete  
- [GAZ-148](https://mifosforge.jira.com/browse/GAZ-148): Refactor create Demo to single screen process  
- [GAZ-149](https://mifosforge.jira.com/browse/GAZ-149): Add logic to insert steps using Add Step button in create demo  
- [GAZ-150](https://mifosforge.jira.com/browse/GAZ-150): Change redirect from upload screen to main menu on demo creation  
- [GAZ-151](https://mifosforge.jira.com/browse/GAZ-151): Handle file name change in demo edits  
- [GAZ-152](https://mifosforge.jira.com/browse/GAZ-152): Add dynamic scroll to create demo screen  
- [GAZ-153](https://mifosforge.jira.com/browse/GAZ-153): Add dynamic scroll to main menu screen for data-table and demo details screen  

[GAZ-125]: https://mifosforge.jira.com/browse/GAZ-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ