### PR TITLE
add source ~/.bashrc cmd to make the just cmd work

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -72,8 +72,24 @@ if ! command -v just &>/dev/null; then
     else
         curl -sSf https://just.systems/install.sh | bash -s -- --to ~/.cargo/bin
         export PATH="$HOME/.cargo/bin:$PATH"
-        echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.bashrc
-        source ~/.bashrc
+        USER_SHELL="$(basename "$SHELL")"
+        case "$USER_SHELL" in
+            zsh)  RC_FILE="$HOME/.zshrc" ;;
+            bash) RC_FILE="$HOME/.bashrc" ;;
+            *)    RC_FILE="$HOME/.profile" ;;
+        esac
+
+        if ! grep -q 'cargo/bin' "$RC_FILE" 2>/dev/null; then
+            echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$RC_FILE"
+        fi
+    fi
+
+    # Verify installation
+    if ! command -v just >/dev/null ; then
+        echo "ERROR: just installed but still not available on PATH"
+        echo "Restart your terminal or run:"
+        echo "  source $RC_FILE"
+        exit 1
     fi
 else
     echo "just is already installed."

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -73,6 +73,7 @@ if ! command -v just &>/dev/null; then
         curl -sSf https://just.systems/install.sh | bash -s -- --to ~/.cargo/bin
         export PATH="$HOME/.cargo/bin:$PATH"
         echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.bashrc
+        source ~/.bashrc
     fi
 else
     echo "just is already installed."


### PR DESCRIPTION
## Before
When we run `bash ./scripts/install_dependencies.sh`,  the `just` command does work and shows this error message, 
`just: command not found`


## After
When I added `source ~/.bashrc` command, the `just` command works perfectly. No error.



## Before screenshot
<img width="1440" height="900" alt="67c14c2cc39726a625b349fc2debe9975c134ab202c31da15484215dfbc49662" src="https://github.com/user-attachments/assets/642dbb52-85d1-4bf5-93c2-6a9dc0229039" />







