### PR TITLE
GAZ-284: Clarify PATH reload requirement after installing 'just'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ just setup
 just run
 # or: .venv/bin/python main.py
 ```
+NOTE: run `source ~/.bashrc` command OR run `just` command in new terminal to avoid `bash: just: command not found error`
 
 ## Usage
 


### PR DESCRIPTION
Update `README.md `to explicitly instruct users to restart their terminal or
source their `~/.bashrc` file after running the installer.