### PR TITLE
GAZ-210: Implementation of Loan and Interest Settings Demo

### DIFF
--- a/demos/latest/GAZ-210-loan-demo.json
+++ b/demos/latest/GAZ-210-loan-demo.json
@@ -1,0 +1,23 @@
+{
+  "demoId": "GAZ-210",
+  "name": "Loan and Interest Settings in MifosX",
+  "description": "Demonstration of declining balance, moratoriums, and prepayments.",
+  "steps": [
+    {
+      "step": 1,
+      "title": "Configure Loan Principal",
+      "details": "Enter a principal amount of 10,000 with a 12% annual interest rate."
+    },
+    {
+      "step": 2,
+      "title": "Set Moratorium Period",
+      "details": "Apply a 3-month moratorium where no principal is repaid."
+    },
+    {
+      "step": 3,
+      "title": "Execute Prepayment",
+      "details": "Apply a $2,000 prepayment in Month 6 to recalculate interest savings."
+    }
+  ],
+  "tags": ["loan", "interest", "demo"]
+}


### PR DESCRIPTION
I've added the loan demo for GAZ-210. It covers the interest settings for a $10k loan with 12% interest, including a 3-month moratorium and a $2k prepayment.

Changes:

Created GAZ-210-loan-demo.json in demos/latest/.

Set up 3 steps showing how interest is recalculated after a prepayment.

Tested the JSON logic against the Gazelle schema.

This demo should now be ready for the Demo-Runtime.