### PR TITLE
GAZ-284: Add missing [kubernetes] section to resolve linux_os_list validation error

### DIFF
--- a/demo_creator/config.py
+++ b/demo_creator/config.py
@@ -6,7 +6,7 @@ GAZELLE_REPO_DIR = os.path.join(GAZELLE_ARTIFACTS_DIR, "mifos-gazelle")
 INI_OUTPUT_FILENAME = os.path.join(GAZELLE_ARTIFACTS_DIR, "mifos-gazelle-config.ini")
 GAZELLE_GIT_URL = "https://github.com/openMF/mifos-gazelle.git"
 GAZELLE_BRANCH_NAME = "dev"
-GAZELLE_DEPLOY_CMD_TMPL = ["sudo", "./run.sh", "-f", "{ini_path}"]
+GAZELLE_DEPLOY_CMD_TMPL = ["sudo", "./run.sh", "-f", "{ini_path}","-m", "{mode}", "-u", "{user}"]
 
 # === deploy_logs_screen.py ===
 LOG_DISPLAY_LIMIT = 100

--- a/demo_creator/schema.py
+++ b/demo_creator/schema.py
@@ -1,4 +1,6 @@
 # TODO: add other required fields
+import os
+_current_user = os.getenv("USER", "ubuntu")
 
 schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -81,7 +83,17 @@ DPG_DEFAULT_CONFIG = {
         "GAZELLE_DOMAIN": "mifos.gazelle.test",
         "GAZELLE_VERSION": "1.1.0",
     },
-    "environment": {"user": "yash-sharma"},
+    "environment": {"user": _current_user},
+    "kubernetes": {
+        "environment": "local",
+        "k8s_user": _current_user,
+        "k8s_version": "1.33",
+        "kubeconfig_path": "~/.kube/config",
+        "min_ram": "6",
+        "min_free_space": "30",
+        "linux_os_list": "Ubuntu",
+        "ubuntu_ok_versions_list": "22 24",
+    },
     "mysql": {
         "MYSQL_SERVICE_NAME": "mysql",
         "MYSQL_SERVICE_PORT": "3306",

--- a/demo_creator/screens/deploy_logs_screen.py
+++ b/demo_creator/screens/deploy_logs_screen.py
@@ -112,10 +112,22 @@ class DeployLogsScreen(Screen):
                 self._thread_safe_log("[green]Repo updated with latest changes!")
             # ---- DEPLOY STEP ----
             self._thread_safe_log("[dim]Starting deployment process...")
-            cmd = [
-                a if a != "{ini_path}" else self.ini_path
-                for a in self.deploy_cmd_template
-            ]
+            import configparser as _cp
+            _cfg = _cp.ConfigParser()
+            _cfg.read(self.ini_path)
+            _mode = _cfg.get("general", "mode", fallback="deploy")
+            _user = os.getenv("USER", os.getenv("LOGNAME", "ubuntu"))
+            cmd = []
+            for a in self.deploy_cmd_template:
+                if a == "{ini_path}":
+                    
+                    cmd.append(self.ini_path)
+                elif a == "{mode}":
+                    cmd.append(_mode)
+                elif a == "{user}":
+                    cmd.append(_user)
+                else:
+                    cmd.append(a)
             proc = subprocess.Popen(
                 cmd,
                 cwd=self.repo_dir,


### PR DESCRIPTION

<img width="2880" height="1800" alt="Image 11-02-26 at 4 18 PM" src="https://github.com/user-attachments/assets/3a5f5108-0d77-47dd-ab40-b3c5fa350e17" />

## Summary
Resolved deployment configuration issues in Gazelle Demo Creator.

## Changes Made
Added [kubernetes] section in mifos-gazelle-config.ini
Updated deployment logic in config.py and schema.py
Also replaced hardcoded yash-sharma with `dynamic _current_user` so any new user is automatically picked up.

## Issues Fixed
`Error: Only Ubuntu is supported in linux_os_list
`
## Testing
Verified deployment proceeds past the OS validation check.