### PR TITLE
GAZ-284: Added -m and -u placeholders to the deploy command template

### DIFF
--- a/demo_creator/config.py
+++ b/demo_creator/config.py
@@ -6,7 +6,7 @@ GAZELLE_REPO_DIR = os.path.join(GAZELLE_ARTIFACTS_DIR, "mifos-gazelle")
 INI_OUTPUT_FILENAME = os.path.join(GAZELLE_ARTIFACTS_DIR, "mifos-gazelle-config.ini")
 GAZELLE_GIT_URL = "https://github.com/openMF/mifos-gazelle.git"
 GAZELLE_BRANCH_NAME = "dev"
-GAZELLE_DEPLOY_CMD_TMPL = ["sudo", "./run.sh", "-f", "{ini_path}"]
+GAZELLE_DEPLOY_CMD_TMPL = ["sudo", "./run.sh", "-f", "{ini_path}","-m", "{mode}", "-u", "{user}"]
 
 # === deploy_logs_screen.py ===
 LOG_DISPLAY_LIMIT = 100

--- a/demo_creator/screens/deploy_logs_screen.py
+++ b/demo_creator/screens/deploy_logs_screen.py
@@ -112,10 +112,21 @@ class DeployLogsScreen(Screen):
                 self._thread_safe_log("[green]Repo updated with latest changes!")
             # ---- DEPLOY STEP ----
             self._thread_safe_log("[dim]Starting deployment process...")
-            cmd = [
-                a if a != "{ini_path}" else self.ini_path
-                for a in self.deploy_cmd_template
-            ]
+            import configparser as _cp
+            _cfg = _cp.ConfigParser()
+            _cfg.read(self.ini_path)
+            _mode = _cfg.get("general", "mode", fallback="deploy")
+            _user = _cfg.get("environment", "user", fallback="")
+            cmd = []
+            for a in self.deploy_cmd_template:
+                if a == "{ini_path}":
+                    cmd.append(self.ini_path)
+                elif a == "{mode}":
+                    cmd.append(_mode)
+                elif a == "{user}":
+                    cmd.append(_user)
+                else:
+                    cmd.append(a)
             proc = subprocess.Popen(
                 cmd,
                 cwd=self.repo_dir,


### PR DESCRIPTION

![WhatsApp Image 2026-02-25 at 22 43 08](https://github.com/user-attachments/assets/af7c92e3-0411-44ed-ba7d-9474994cd412)
## Summary
Deployment was failing because run.sh requires -m (mode) and -u (user) as mandatory command-line arguments, but they were not being passed by the deploy command.

## Changes Made
Updated GAZELLE_DEPLOY_CMD_TMPL to include required -m and -u placeholders.
Added logic to read mode from config.ini

## Issues Fixed
`Error: Required options -m (mode) and -u (user) must be provided.`

## Testing
Deployment proceeds past the CLI validation stage.
