### PR TITLE
GAZ-284:  Add Ctrl+Z suspend keybinding to exit TUI and return to terminal

### DIFF
--- a/demo_creator/app.py
+++ b/demo_creator/app.py
@@ -11,7 +11,8 @@ from demo_creator.screens import (
 class DemoCreatorApp(App):
     CSS_PATH = "./assets/base.tcss"
 
-    BINDINGS = [ 
+    BINDINGS = [
+       Binding("ctrl+q", "quit", "Quit", show=True),  
        Binding("ctrl+z", "suspend_process", "Suspend (go to terminal)", show=True), 
     ]
 

--- a/demo_creator/app.py
+++ b/demo_creator/app.py
@@ -1,4 +1,5 @@
 from textual.app import App
+from textual.binding import Binding
 from demo_creator.screens import (
     LoginScreen,
     MainMenuScreen,
@@ -9,6 +10,10 @@ from demo_creator.screens import (
 
 class DemoCreatorApp(App):
     CSS_PATH = "./assets/base.tcss"
+
+    BINDINGS = [ 
+       Binding("ctrl+z", "suspend_process", "Suspend (go to terminal)", show=True), 
+    ]
 
     def on_mount(self):
         self.push_screen(LoginScreen())


### PR DESCRIPTION
## Problem
There was no way to exit the TUI interface and return to the terminal
![WhatsApp Image 2026-02-27 at 15 52 41](https://github.com/user-attachments/assets/c4fab8ba-758f-41d2-a16d-1f58c6b79efd)
Ctrl+Q does not work for VS Code/Codespaces users as it is 
intercepted by VS Code to open the folder structure. As a result, can't exit TUI.

## Solution
Added `Ctrl+Z` → `suspend_process` binding to the main App class.
This suspends the TUI and drops the user back to the terminal.

## Changes
`demo_creator/app.py` — added `BINDINGS` with `Ctrl+Z` suspend binding

## Testing
Tested on local Linux — `Ctrl+Z` suspends TUI cleanly, 