### PR TITLE
GAZ-278: Added examples directory with sample demo JSON for local testing (FIXES GAZ-207).

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
 - **User Guide:** see [USER_GUIDE.md](./docs/USER_GUIDE.md)
 - **Architecture & repo layout:** see [ARCHITECTURE.md](./docs/ARCHITECTURE.md)
 
-## Demo
-
-[![Demo](https://asciinema.org/a/qcQj06vwexiCaWfs.svg)](https://asciinema.org/a/qcQj06vwexiCaWfs)
-
 ## Features
 
 - Create demo files with steps, descriptions, and tags

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 - **User Guide:** see [USER_GUIDE.md](./docs/USER_GUIDE.md)
 - **Architecture & repo layout:** see [ARCHITECTURE.md](./docs/ARCHITECTURE.md)
 
+## Demo
+
+[![Demo](https://asciinema.org/a/qcQj06vwexiCaWfs.svg)](https://asciinema.org/a/qcQj06vwexiCaWfs)
+
 ## Features
 
 - Create demo files with steps, descriptions, and tags

--- a/examples/batch_payments_flow_from_phee__mifos_x.json
+++ b/examples/batch_payments_flow_from_phee__mifos_x.json
@@ -1,0 +1,36 @@
+{
+  "demoName": "Batch Payments flow from PHEE - Mifos X",
+  "demoDescription": "End-to-end batch payment flow from Payment Hub EE to Mifos X",
+  "tags": [
+    "MifosX",
+    "Phee"
+  ],
+  "steps": {
+    "1": {
+      "title": "Login to Ops Web",
+      "url": "https://ops.mifos.gazelle.test",
+      "details": "Login with default credentials to access the Payment Hub EE Operations Web"
+    },
+    "2": {
+      "title": "Upload Batch CSV",
+      "url": "https://ops.mifos.gazelle.test",
+      "details": "Upload the pre-generated bulk payment CSV file for the batch transaction"
+    },
+    "3": {
+      "title": "Approve the Batch",
+      "url": "https://ops.mifos.gazelle.test",
+      "details": "Review and approve the batch payment request"
+    },
+    "4": {
+      "title": "Monitor Batch Status",
+      "url": "https://ops.mifos.gazelle.test",
+      "details": "Monitor the batch processing status until completion"
+    },
+    "5": {
+      "title": "Verify Payments in MifosX",
+      "url": "http://mifos.mifos.gazelle.test",
+      "details": "Login to MifosX and verify the payments have been received"
+    }
+  },
+  "demoId": "4f187905-c47e-4ebd-a095-ba254e8bfd80"
+}

--- a/examples/metadata.json
+++ b/examples/metadata.json
@@ -1,0 +1,21 @@
+{
+  "demos": [
+    {
+      "demoId": "4f187905-c47e-4ebd-a095-ba254e8bfd80",
+      "name": "Batch Payments flow from PHEE - Mifos X",
+      "file_name": "batch_payments_flow_from_phee__mifos_x.json",
+      "description": "End-to-end batch payment flow from Payment Hub EE to Mifos X",
+      "version": 1,
+      "steps_count": 5,
+      "created_at": "2026-04-20T09:42:33Z",
+      "updated_at": "2026-04-22T11:03:55Z",
+      "created_by": "kanishk05",
+      "last_modified_by": "kanishk05",
+      "deleted": false,
+      "tags": [
+        "MifosX",
+        "Phee"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Problem**
There was no way to add new demos without JFrog credentials. Also, there was no standard place to store demo JSON files.

**Solution**
Added an `examples/ directory` to the repo as the canonical location for demo JSON files. We can now add demos by submitting a PR, no JFrog access needed.

**Changes**
`examples/metadata.json`: metadata index of all demos in the examples directory.
`examples/batch_payments_flow_from_phee__mifos_x.json`: added Batch Payments flow from PHEE - Mifos X as the first example demo.

**Testing**
Verified that Demo Runtime correctly picks up the demo JSON from `public/examples/ `when `VITE_API_URL` is not set. The Batch Payments demo rendered end-to-end successfully.

<img width="1440" height="900" alt="Screenshot 2026-04-23 at 12 17 30 PM" src="https://github.com/user-attachments/assets/c0d16a5f-302a-4da0-abe7-48fe1bc8d9bb" />
<img width="1440" height="900" alt="Screenshot 2026-04-23 at 12 17 00 PM" src="https://github.com/user-attachments/assets/ba39d2f9-f316-4873-8067-8dacf2d5fa72" />


