### PR TITLE
GAZ-283: Updated README to document the 'just publish' workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - Create demo files with steps, descriptions, and tags
 - View, edit, and delete demos with versioned metadata
-- Sync deletions and upload demos to Artifactory
+- Sync and publish demos locally using `just publish` or upload to Artifactory via JFrog
 - Configure and deploy DPG environments with live logs using mifos-gazelle
 
 ## Quick Start
@@ -31,13 +31,32 @@ just run
 ```
 NOTE: run `source ~/.bashrc` command OR run `just` command in new terminal to avoid `bash: just: command not found error`
 
+## Workflow
+
+After setting up the project, follow these steps to create a demo and view it in Demo Runtime:
+
+```bash
+# Step 1 - Create a demo in the TUI
+just run
+
+# Step 2 - Sync your demo to mifos-gazelle-demo-runtime
+just publish
+
+# Step 3 - View your demo in Demo Runtime
+# Navigate to mifos-gazelle-demo-runtime repo and run:
+npm start
+```
+
+> Note: `just publish` requires mifos-gazelle-demo-runtime to be cloned.
+> Set the path in `.env` file (see `.env.example`).
+
 ## Usage
 
 - **Login:** enter username and email
 - **Main Menu:** Create Demo, Upload Demo, Deploy DPG
 - **Create Demo:** add steps (title, URL, details), tags, submit to save
 - **Demo Details:** inspect/edit/delete demos
-- **Upload:** sync deletions and upload to JFrog
+- **Publish:** run `just publish` to sync demos locally to demo-runtime, or use Upload Demo to push to JFrog
 - **Deploy:** edit config, confirm, and watch logs
 
 ## Configuration


### PR DESCRIPTION
## Problem
The just publish command was added in PR #22, but was never documented 
in the README. Contributors had no way of knowing they need to run 
`just publish` after creating a demo to sync it to demo-runtime.

## Solution
Updated README to document the complete workflow and clarify both 
publishing options available to contributors.

## Changes
- Added Workflow section documenting the full end-to-end flow
- Updated Features section to mention just publish alongside JFrog
- Updated Usage section to reflect both publish and JFrog options

